### PR TITLE
add tag workflow 

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,25 @@
+name: tag
+
+on:
+  workflow_dispatch:
+    branches:
+      - main
+
+jobs:
+  tag:
+    name: tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: determine next tag
+        uses: mathieudutour/github-tag-action@v6.2
+        id: tag
+        with:
+          dry_run: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: show tag and changelog
+        run: |
+          echo "Tag: ${{ steps.tag.outputs.new_tag }}"
+          echo "Changelog:"
+          echo "${{ steps.tag.outputs.changelog }}"


### PR DESCRIPTION
This PR adds a manual workflow to determine the next release tag based on conventional commits.