### PR TITLE
feat: add check for linux capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Install or upgrade `talos-vmtoolsd`:
 kubectl apply --filename https://raw.githubusercontent.com/siderolabs/talos-vmtoolsd/master/deploy/latest.yaml
 ```
 
-Remember
+The `CAP_SYS_RAWIO` capability is used to perform a check to determine whether the environment is VMware.
+This check can be skipped by setting env var `SKIP_VMWARE_DETECTION=true`.
+Note that `Segmentation fault` will be produced if the environment is **not** VMware.
 
 ## Talos Compatibility Matrix
 

--- a/deploy/latest.yaml
+++ b/deploy/latest.yaml
@@ -52,12 +52,18 @@ spec:
               memory: 64Mi
               cpu: 500m
           securityContext:
+            privileged: false
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
-            runAsUser: 1002
-            runAsGroup: 1002
+            runAsUser: 0
+            runAsGroup: 0
+            capabilities:
+              drop:
+                - all
+              add:
+                - SYS_RAWIO # Override with SKIP_VMWARE_DETECTION
       securityContext:
-        fsGroup: 1002
+        fsGroup: 0
       volumes:
         - name: config
           secret:

--- a/internal/capcheck/capcheck.go
+++ b/internal/capcheck/capcheck.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2020 Oliver Kuckertz, Siderolabs and Equinix
+// SPDX-License-Identifier: Apache-2.0
+
+// Package capcheck implements CheckCapabilities
+package capcheck
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// CheckCapabilities checks natively if a given LINUX capability is granted
+// Capability (position) is in bits, only for reference
+// https://pkg.go.dev/github.com/syndtr/gocapability/capability#pkg-constants
+func CheckCapabilities(capabilityBit int8) error {
+	procStatus, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return fmt.Errorf("error reading /proc/self/status: %w", err)
+	}
+
+	for _, line := range strings.Split(string(procStatus), "\n") {
+		if strings.HasPrefix(line, "CapEff:") {
+			parts := strings.Fields(line)
+			if len(parts) < 2 {
+				return fmt.Errorf("invalid CapEff line format")
+			}
+			// read as hexadecimal number (base 16).
+			val, err := strconv.ParseUint(parts[1], 16, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing CapEff value: %w", err)
+			}
+			// Create bitmask and bitwise to determine if capability (as decicmal) is set
+			if val&(1<<capabilityBit) != 0 {
+				return nil
+			}
+
+			return fmt.Errorf("capability (%v) is not granted inside current environment", capabilityBit)
+		}
+	}
+
+	return fmt.Errorf("capEff line not found")
+}


### PR DESCRIPTION
Add checks for CAP_SYS_RAWIO which is needed for iopl during the VMware environment check.

In some cases this capability might be considered a security issue; therefore, the env var SKIP_VMWARE_DETECTION is added to skip the check entirely.

Closes #37 